### PR TITLE
Pitch perfect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nsq-relayer
 
-You emit events structured in a specific way and this tool posts them all to its configured nsq instance.
+You emit events structured in a specific way and this tool publishes them all to its configured nsq instance.
 
 ```js
 const createRelayer = require('nsq-relayer');
@@ -13,7 +13,7 @@ const relayer = createRelayer({
 
 // later on
 process.emit('event-to-listen-for', { name: 'my-little-message', type: 'cutie-mark' });
-// the relayer will then post this to nsq for us with zero effort
+// the relayer will then publish this to nsq for us with zero effort
 ```
 
 ## Configuration
@@ -22,9 +22,9 @@ TBD.
 
 ## Notes
 
-No attempt is made to retry failed event posts.
+No attempt is made to retry failed publishes.
 
-Each event is posted as it arrives, without batching. You might want to batch if you're posting many events per second.
+Each event is published as it arrives, without batching. You might want to batch if you're publishing many events per second.
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ const createRelayer = require('nsq-relayer');
 
 const relayer = createRelayer({
 	topic: 'foozle',
-	nsq: 'http://localhost:5141',
+	nsq: 'nsq://localhost:4150',
 	event: 'event-to-listen-for'
 });
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function createRelayer(opts = {})
 
 class NSQRelayer
 {
-	constructor({ nsq = 'http://localhost:4150', topic = 'relayed', event = 'nsq' })
+	constructor({ nsq = 'nsq://localhost:4150', topic = 'relayed', event = 'nsq' })
 	{
 		const parsed = url.parse(nsq);
 		this.nsq = new Squeaky({ host: parsed.hostname, port: parsed.port || 4150 });


### PR DESCRIPTION
Previously worked over HTTP. With the switch to `squeaky` this works over NSQ's native TCP protocol only. Language in README uses the term `publish` in favor of `post`. URIs now use the `nsq:` protocol.